### PR TITLE
Set argument list fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Retrieve the values belonging to a series of keys. If a key is not found, it wil
 
 Set a value by a given key. All [available cache modules](#available-cache-modules) attempt to `JSON.stringify` all values passed to `.set()` and `JSON.parse` all values returned from `.get()`.
 
-> IMPORTANT: The `callback` params takes precedence over the `refresh` param. This means that, when only four arguments are passed and the last param is a function, `cache-service` will assume the last param is `callback`. Similarly, if three params are passed and the third is a function, `cache-service` will assume the third param is `callback` rather than `refresh`. This is done to maintain backwards compatibility with versions released before the `background refresh` feature was added.
+> IMPORTANT: The `callback` param takes precedence over the `refresh` param. This means that, when only four arguments are passed and the last param is a function, `cache-service` will assume the last param is `callback`. Similarly, if three params are passed and the third is a function, `cache-service` will assume the third param is `callback` rather than `refresh`. This is done to maintain backwards compatibility with versions released before the `background refresh` feature was added.
 
 * key: type: string
 * callback: type: function

--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ Retrieve the values belonging to a series of keys. If a key is not found, it wil
 
 Set a value by a given key. All [available cache modules](#available-cache-modules) attempt to `JSON.stringify` all values passed to `.set()` and `JSON.parse` all values returned from `.get()`.
 
+> IMPORTANT: The `callback` params takes precedence over the `refresh` param. This means that, when only four arguments are passed and the last param is a function, `cache-service` will assume the last param is `callback`. Similarly, if three params are passed and the third is a function, `cache-service` will assume the third param is `callback` rather than `refresh`. This is done to maintain backwards compatibility with versions released before the `background refresh` feature was added.
+
 * key: type: string
 * callback: type: function
 * expiration: type: int, measure: seconds

--- a/cacheService.js
+++ b/cacheService.js
@@ -134,9 +134,23 @@ function cacheService(cacheServiceConfig, cacheModules) {
     var key = arguments[0];
     var value = arguments[1];
     var expiration = arguments[2] || null;
-    var refresh = (arguments.length === 5) ? arguments[3] : null;
-    var cb = (arguments.length === 5) ? arguments[4] : arguments[3];
-    cb = cb || noop;
+    var refresh = arguments[3] || null;
+    var cb = arguments[4] || noop;
+    if(arguments.length === 4 && typeof arguments[3] === 'function'){
+      cb = arguments[3];
+      if(typeof arguments[2] === 'function'){
+        refresh = arguments[2];
+        expiration = null;
+      }
+      else{
+        expiration = arguments[2];
+        refresh = null;
+      }
+    }
+    else if(arguments.length === 3 && typeof arguments[2] === 'function'){
+      cb = arguments[2];
+      expiration = null;
+    }
     log(false, '.set() called:', {key: key, value: value});
     for(var i = 0; i < self.cachesLength; i++){
       var cache = self.caches[i];


### PR DESCRIPTION
* Fix a bug preventing `.set()` from correctly handling three parameters when the third parameter is a callback function (thanks to @thanpolas)
* Updated documentation to make it clear that the `callback` param always takes precedence over the `refresh` param when calling `.set()`.