### PR TITLE
Change (some) callbacks to only trigger when complete.

### DIFF
--- a/cacheService.js
+++ b/cacheService.js
@@ -152,11 +152,17 @@ function cacheService(cacheServiceConfig, cacheModules) {
       expiration = null;
     }
     log(false, '.set() called:', {key: key, value: value});
+    var moduleCallbacks = 0;
     for(var i = 0; i < self.cachesLength; i++){
       var cache = self.caches[i];
       var ref = (i === self.caches.length - 1) ? refresh : null;
-      var func = (i === 0) ? cb : noop;
-      cache.set(key, value, expiration, ref, func);
+      cache.set(key, value, expiration, ref, moduleCallback);
+    }
+    function moduleCallback(err){
+      if (++moduleCallbacks === self.cachesLength){
+        // note: no errors are passed back!
+        cb(null);
+      }
     }
   };
 
@@ -174,14 +180,16 @@ function cacheService(cacheServiceConfig, cacheModules) {
     var expiration = arguments[1] || null;
     var cb = arguments[2] || null;
     log(false, '.mset() called:', {data: obj});
+    var moduleCallbacks = 0;
     for(var i = 0; i < self.cachesLength; i++){
       var cache = self.caches[i];
       expiration = expiration || cache.expiration;
-      if(i === self.caches.length - 1){
-        cache.mset(obj, expiration, cb);
-      }
-      else{
-        cache.mset(obj, expiration);
+      cache.mset(obj, expiration, moduleCallback);
+    }
+    function moduleCallback(err){
+      if (++moduleCallbacks === self.cachesLength){
+        // note: no errors are passed back!
+        cb(null);
       }
     }
   };
@@ -196,13 +204,15 @@ function cacheService(cacheServiceConfig, cacheModules) {
       throw new Exception('INCORRECT_ARGUMENT_EXCEPTION', '.del() requires a minimum of 1 argument.');
     }
     log(false, '.del() called:', {keys: keys});
+    var moduleCallbacks = 0;
     for(var i = 0; i < self.cachesLength; i++){
       var cache = self.caches[i];
-      if(i === self.caches.length - 1){
-        cache.del(keys, cb);
-      }
-      else{
-        cache.del(keys);
+      cache.del(keys, moduleCallback);
+    }
+    function moduleCallback(err){
+      if (++moduleCallbacks === self.cachesLength){
+        // note: no errors are passed back!
+        cb(null);
       }
     }
   };
@@ -213,13 +223,15 @@ function cacheService(cacheServiceConfig, cacheModules) {
    */
   self.flush = function(cb){
     log(false, '.flush() called');
+    var moduleCallbacks = 0;
     for(var i = 0; i < self.cachesLength; i++){
       var cache = self.caches[i];
-      if(i === self.caches.length - 1){
-        cache.flush(cb);
-      }
-      else{
-        cache.flush();
+      cache.flush(moduleCallback);
+    }
+    function moduleCallback(err){
+      if (++moduleCallbacks === self.cachesLength){
+        // note: no errors are passed back!
+        cb(null);
       }
     }
   };


### PR DESCRIPTION
This is a proof-of-concept PR for the issue raised in https://github.com/jpodwys/cache-service/issues/22.  In particular, the caller-provided callback is only called when _all_ of the cache modules have completed.

In making this change, I discovered several other issues that should probably be addressed.

* In general the cache-service "writing" APIs (`.set()`, `.mset()`, `.del()`, and `.flush()`) don't define what the caller-provided callback will be passed on success, failure, or partial failure.  (I suspect cache-service will need to define something like an "aggregate error" to encapsulate the "one or more modules had a problem" scenario.)

* The `.get()` API implies (by "response... null on cache miss") that a cache miss should _not_ pass an error value to the callback; this should likely be explicit.  On the other hand, cache-service's implementation handles module `.get()` errors by simply trying the next module, so perhaps cache-misses _should_ be handled by an error value, allowing _any_ value (including null and undefined) for a cache-hit.

* The _module_ API doesn't specify what should be passed to the callback on success or failure.  Is only the `err` argument used?  Is _nothing_ inspected, and the callback used only to indicate completion?