### PR TITLE
Add cache-service-memcached reference, update tests using memcached cache module

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ var refresh = function(key, cb){
 
 A redis wrapper for cache-service or standalone use. [Available on NPM](https://github.com/jpodwys/cache-service-redis).
 
+#### cache-service-memcached
+
+A memcached wrapper for cache-service or standalone use. [Available on NPM](https://www.npmjs.com/package/cache-service-memcached).
+
 #### cache-service-node-cache
 
 An in-memory cache wrapper for cache-service or standalone use. [Available on NPM](https://github.com/jpodwys/cache-service-node-cache).

--- a/package.json
+++ b/package.json
@@ -7,10 +7,13 @@
     "cache-service-cache-module": "1.x"
   },
   "devDependencies": {
+    "cache-service-memcached": "^1.0.0-beta.1",
     "cache-service-node-cache": "1.1.0",
     "cache-service-redis": "1.1.0",
     "expect": "1.6.0",
+    "memcached-mock": "^0.1.0",
     "mocha": "2.2.4",
+    "proxyquire": "^1.7.11",
     "redis-js": "0.0.12-6"
   },
   "scripts": {
@@ -33,6 +36,7 @@
     "cache",
     "node",
     "redis",
+    "memcached",
     "node-cache",
     "tiered"
   ]

--- a/test/server/cache-service.js
+++ b/test/server/cache-service.js
@@ -7,8 +7,13 @@ var redisMock = require('redis-js');
 var redisCache = new rcModule({redisMock: redisMock});
 var cModule = require('cache-service-cache-module');
 var cacheModule = new cModule();
+var memcachedMock = require('memcached-mock');
+var proxyquire = require('proxyquire');
+var MemcachedCacheModule = proxyquire('cache-service-memcached', { memcached: memcachedMock });
+var memcached = new MemcachedCacheModule();
 var cacheService = new cs({writeToVolatileCaches: false}, [
   redisCache,
+  memcached,
   cacheModule,
   nodeCache
 ]);
@@ -213,8 +218,11 @@ describe('cachService background refresh tests', function () {
           cacheService.caches[1].get(key, function (err, response){
             expect(response).toBe(null);
             cacheService.caches[2].get(key, function (err, response){
-              expect(response).toBe(1);
-              done();
+              expect(response).toBe(null);
+              cacheService.caches[3].get(key, function (err, response){
+                expect(response).toBe(1);
+                done();
+              });
             });
           });
         });


### PR DESCRIPTION
Hey @jpodwys, thanks for the cache-service! 
I've created cache-service-memcached. I think, it would be useful to reference it in cache-service. 
Also, tests are updated using cache-service-memcached.
Please, take a look.